### PR TITLE
[修正] collect.py 明確以 UTF-8 讀寫證據檔

### DIFF
--- a/evals/test_collect_utf8.py
+++ b/evals/test_collect_utf8.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+import json
+import os
+import pathlib
+import runpy
+import sys
+import tempfile
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+COLLECT = ROOT / "scripts" / "collect.py"
+MESSAGE = "繁體中文測試：驗證 UTF-8 原句。"
+
+
+def main():
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = pathlib.Path(tmp)
+        claude_root = tmp / "claude"
+        session = claude_root / "projects" / "fixture" / "utf8.jsonl"
+        session.parent.mkdir(parents=True)
+        records = [
+            {
+                "type": "user",
+                "timestamp": "2026-09-08T12:00:00+08:00",
+                "entrypoint": "cli",
+                "origin": {"kind": "human"},
+                "message": {"content": MESSAGE},
+            },
+            {
+                "type": "assistant",
+                "timestamp": "2026-09-08T12:00:01+08:00",
+                "message": {"content": "ok"},
+            },
+        ]
+        session.write_text("\n".join(json.dumps(r, ensure_ascii=False) for r in records) + "\n",
+                           encoding="utf-8")
+        out = tmp / "evidence"
+        assert "PYTHONUTF8" not in os.environ
+        assert "PYTHONIOENCODING" not in os.environ
+        old_argv = sys.argv
+        try:
+            sys.argv = [str(COLLECT), "--source", "claude-code",
+                        "--claude-root", str(claude_root), "--codex-root", str(tmp / "codex"),
+                        "--since", "2026-09-08", "--until", "2026-09-08", "--out", str(out)]
+            runpy.run_path(str(COLLECT), run_name="__main__")
+        finally:
+            sys.argv = old_argv
+        summary = json.loads((out / "summary.json").read_text(encoding="utf-8"))
+        cases = (out / "cases.md").read_text(encoding="utf-8")
+        metrics = (out / "metrics.md").read_text(encoding="utf-8")
+        assert summary["human_usage"]["user_messages"] == 1
+        assert MESSAGE in cases
+        assert "證據包計數" in metrics
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/collect.py
+++ b/scripts/collect.py
@@ -455,7 +455,7 @@ def proto_unix_ts(blob):
 
 def iter_jsonl(path):
     try:
-        with open(path, "r", errors="ignore") as fh:
+        with open(path, "r", encoding="utf-8", errors="ignore") as fh:
             for line in fh:
                 line = line.strip()
                 if not line:
@@ -694,7 +694,7 @@ def agy_title(ann_path):
     if not os.path.isfile(ann_path):
         return ""
     try:
-        text = open(ann_path, errors="ignore").read(4000)
+        text = open(ann_path, encoding="utf-8", errors="ignore").read(4000)
     except OSError:
         return ""
     m = AGY_TITLE_RE.search(text)
@@ -1270,11 +1270,11 @@ def main():
     os.makedirs(out, exist_ok=True)
 
     summary = build_summary(sessions, since, until, used)
-    with open(os.path.join(out, "summary.json"), "w") as fh:
+    with open(os.path.join(out, "summary.json"), "w", encoding="utf-8") as fh:
         json.dump(summary, fh, ensure_ascii=False, indent=2)
-    with open(os.path.join(out, "metrics.md"), "w") as fh:
+    with open(os.path.join(out, "metrics.md"), "w", encoding="utf-8") as fh:
         fh.write(render_metrics(summary) + "\n")
-    with open(os.path.join(out, "cases.md"), "w") as fh:
+    with open(os.path.join(out, "cases.md"), "w", encoding="utf-8") as fh:
         fh.write(render_cases(sessions, args.cases, not args.no_content) + "\n")
 
     sp, h = summary["session_split"], summary["human_usage"]


### PR DESCRIPTION
Fixes #2

## 修正內容

在 `collect.py` 的 5 個檔案讀寫位置明確指定 `encoding=utf-8`：

- UTF-8 JSONL transcript reader
- annotation reader
- `summary.json`
- `metrics.md`
- `cases.md`

保留既有 `errors=ignore` 行為；本 PR 不改變損毀輸入資料的處理策略。

## 測試

新增 `evals/test_collect_utf8.py`：

- 使用完全合成的 UTF-8 JSONL fixture
- 包含 Traditional Chinese text
- 明確確認未設定 `PYTHONUTF8` 與 `PYTHONIOENCODING`
- 驗證輸出的 `summary.json`、`metrics.md`、`cases.md` 都可用 UTF-8 正確讀回
- 在 Windows、Python 3.12.14、`locale.getpreferredencoding(False) == cp950`、`utf8_mode=0` 下實測通過

## 範圍

這是單一、窄範圍的 encoding 修正，未改變 collector 的資料分類、計數或報告判定邏輯。

## 待 maintainer 確認

`CONTRIBUTING.md` 建議 scripts 修改附同一份資料的改前／改後數字對照。本次為保護真實對話內容，PR 僅附可重現的合成 fixture；若 maintainer 要求數字對照，請告知可接受的去識別化格式。